### PR TITLE
Fixed generation of HTTP manifest URLs for base uris with signatures

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -30,6 +30,14 @@ Fixed
 Security
 ^^^^^^^^
 
+[0.5.2] - 2025-03-28
+--------------------
+
+Fixed
+^^^^^
+
+- Generation of HTTP manifest URLs for base uris with signatures
+
 
 [0.5.1] - 2021-06-23
 --------------------


### PR DESCRIPTION
The URL for the `http_manifest.json`  was just attached to the base URI, which does not work if the base URI contains a query parameter with a signature (from the S3 storage broker).